### PR TITLE
Wpp 65 Gateway SSO support Portlet Preferences authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,12 @@
             <groupId>taglibs</groupId>
             <artifactId>standard</artifactId>
         </dependency>
+        <dependency> 
+            <groupId>org.jasypt</groupId> 
+            <artifactId>jasypt</artifactId>  
+            <version>1.6</version>
+        </dependency>
+        
     </dependencies>
 
     <build>

--- a/src/main/java/org/jasig/portlet/proxy/mvc/portlet/gateway/GatewayPortletController.java
+++ b/src/main/java/org/jasig/portlet/proxy/mvc/portlet/gateway/GatewayPortletController.java
@@ -25,8 +25,6 @@ import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
-import javax.portlet.PortletPreferences;
 import javax.portlet.RenderRequest;
 import javax.portlet.ResourceRequest;
 import javax.portlet.ResourceResponse;

--- a/src/main/java/org/jasig/portlet/proxy/mvc/portlet/gateway/GatewayPortletController.java
+++ b/src/main/java/org/jasig/portlet/proxy/mvc/portlet/gateway/GatewayPortletController.java
@@ -23,6 +23,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import javax.portlet.PortletPreferences;
 import javax.portlet.RenderRequest;
 import javax.portlet.ResourceRequest;
 import javax.portlet.ResourceResponse;
@@ -42,7 +46,9 @@ import org.springframework.web.portlet.bind.annotation.ResourceMapping;
 @Controller
 @RequestMapping("VIEW")
 public class GatewayPortletController {
-	
+
+    protected final Logger logger = LoggerFactory.getLogger(this.getClass());
+    
 	@Autowired(required=false)
 	private String viewName = "gateway";
 	
@@ -80,8 +86,9 @@ public class GatewayPortletController {
 		for (Map.Entry<HttpContentRequestImpl, List<String>> requestEntry : entry.getContentRequests().entrySet()){
 			
 			// run each content request through any configured preinterceptors
-			// before adding it to the list
-			final HttpContentRequestImpl contentRequest = requestEntry.getKey();
+			// before adding it to the list.  Use a clone so that future changes to environment
+			// will accurately be intercepted.
+			final HttpContentRequestImpl contentRequest = requestEntry.getKey().duplicate();
 			for (String interceptorKey : requestEntry.getValue()) {
 				final IPreInterceptor interceptor = applicationContext.getBean(interceptorKey, IPreInterceptor.class);
 				interceptor.intercept(contentRequest, portletRequest);

--- a/src/main/java/org/jasig/portlet/proxy/mvc/portlet/gateway/GatewayPortletController.java
+++ b/src/main/java/org/jasig/portlet/proxy/mvc/portlet/gateway/GatewayPortletController.java
@@ -94,7 +94,6 @@ public class GatewayPortletController {
 			contentRequests.add(contentRequest);
 		}
 		mv.addObject("contentRequests", contentRequests);
-
 		// we don't want this response to be cached by the browser since it may
 		// include one-time-only authentication tokens
         portletResponse.getCacheControl().setExpirationTime(1);

--- a/src/main/java/org/jasig/portlet/proxy/mvc/portlet/gateway/GatewayPortletEditController.java
+++ b/src/main/java/org/jasig/portlet/proxy/mvc/portlet/gateway/GatewayPortletEditController.java
@@ -18,8 +18,6 @@
  */
 package org.jasig.portlet.proxy.mvc.portlet.gateway;
 
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -27,35 +25,35 @@ import java.util.Map;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
+import javax.portlet.PortletMode;
 import javax.portlet.PortletPreferences;
-import javax.portlet.ReadOnlyException;
 import javax.portlet.RenderRequest;
-import javax.portlet.ResourceRequest;
-import javax.portlet.ResourceResponse;
-import javax.portlet.ValidatorException;
-
 import org.jasig.portlet.proxy.mvc.IViewSelector;
 import org.jasig.portlet.proxy.mvc.portlet.gateway.GatewayEntry;
+import org.jasig.portlet.proxy.service.IFormField;
+import org.jasig.portlet.proxy.service.web.FormFieldImpl;
 import org.jasig.portlet.proxy.service.web.HttpContentRequestImpl;
-import org.jasig.portlet.proxy.service.web.interceptor.IPreInterceptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.portlet.ModelAndView;
-import org.springframework.web.portlet.bind.annotation.RenderMapping;
-import org.springframework.web.portlet.bind.annotation.ResourceMapping;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 
 @Controller
 @RequestMapping("EDIT")
 public class GatewayPortletEditController {
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
+    private String preferencesRegex;
+    
+    @Value("#{props['login.preferences.regex']}")
+    public void setPreferencesRegex(String preferencesRegex) {
+    	this.preferencesRegex = preferencesRegex;
+    }
+    
     @Autowired(required=false)
     private String viewName = "gatewayEdit";
     
@@ -70,107 +68,38 @@ public class GatewayPortletEditController {
 
     @RequestMapping
     public ModelAndView getView(RenderRequest request){
-        final PortletPreferences preferences = request.getPreferences();
+    	
+        PortletPreferences prefs = request.getPreferences();
 
         final ModelAndView mv = new ModelAndView();
         final List<GatewayEntry> entries =  (List<GatewayEntry>) applicationContext.getBean("gatewayEntries", List.class);
         
-        // debugging block, remove before committing
-//        logger.warn("Proxy entries");
-//        for (GatewayEntry entry: entries) {
-//            logger.warn("name: " + entry.getName());
-//            for (HttpContentRequestImpl key:  entry.getContentRequests().keySet()) {
-//                for (String strKey: key.getParameters().keySet()) {
-//                    String[] values = key.getParameters().get(strKey);
-//                    for (String val: values) {
-//                        logger.warn("\tkey: " + strKey + ", value: " + val); 
-//                    }
-//                }
-//            }
-//        }
-        logger.warn("Proxy Preferences");
-        Enumeration<String> names = preferences.getNames();
-        while (names.hasMoreElements()) {
-            String preferenceName = names.nextElement();
-            logger.warn("preferenceName: " + preferenceName);
-            final String[] abc = preferences.getValues(preferenceName, new String[0]);
-            if (abc.length > 0) {
-                logger.warn("abc.length: " + abc.length + ", value: " + abc[0]);
-            }
-        }
-        // end debugging block
-        
-        // perform substitution for any fields stored in userInfo, referenced in the config file
-//        for (GatewayEntry entry: entries) {
-//            for (Map.Entry<HttpContentRequestImpl, List<String>> requestEntry : entry.getContentRequests().entrySet()){
-//                
-//                // run each content request through any configured preinterceptors
-//                // before adding it to the list
-//                final HttpContentRequestImpl contentRequest = requestEntry.getKey();
-//                for (String interceptorKey : requestEntry.getValue()) {
-//                    final IPreInterceptor interceptor = applicationContext.getBean(interceptorKey, IPreInterceptor.class);
-//                    logger.warn("interceptor: " + interceptor.getClass().getCanonicalName());
-//                    interceptor.intercept(contentRequest, request);
-//                }
-//            }
-//        }
-        
-        Map<String, Map<String, String>> apps = new LinkedHashMap<String, Map<String, String>>();
+        // look for any preferences that are present in any of the gatewayEntry objects.
+        // store them in a list so that they can be edited.
+        Map<String, IFormField> preferredParameters = new LinkedHashMap<String, IFormField>();
         for (GatewayEntry entry: entries) {
-//            logger.warn("entry: " + entry.getName());
             for (Map.Entry<HttpContentRequestImpl, List<String>> requestEntry : entry.getContentRequests().entrySet()){
                 final HttpContentRequestImpl contentRequest = requestEntry.getKey();
-                Map<String, String[]> parameters = contentRequest.getParameters();
+                Map<String, IFormField> parameters = contentRequest.getParameters();
                 for (String parameterKey : parameters.keySet()) {
-//                    logger.warn("parameterKey: " + parameterKey);
-                    String[] parameterValues = parameters.get(parameterKey);
+                	IFormField parameter = parameters.get(parameterKey);
+                    String[] parameterValues = parameter.getValues();
                     for (int i = 0; i < parameterValues.length; i++) {
                         String parameterValue = parameterValues[i];
-//                        logger.warn("parameterValue: " + parameterValue);
-                        if (parameterValue.matches("\\{prefs\\.[\\w.]+\\}")) {
-//                            logger.warn("regex match");
-                            Map<String, String> app = apps.get(entry.getName());
-                            if (app == null) {
-//                                logger.warn("add new app");
-                                app = new LinkedHashMap<String, String>();
-                                apps.put(entry.getName(), app);
-                            }
+                        logger.warn("regex: " + preferencesRegex);
+                        if (parameterValue.matches(preferencesRegex)) {
                             
                             // retrieve the preference and stuff the value here....
-                            PortletPreferences prefs = request.getPreferences();
-                            String preferredValue = prefs.getValue(parameterKey, parameterValue);
-                            
-                            
-                            app.put(parameterKey, preferredValue);
+                            String preferredValue = prefs.getValue(parameterValue, parameterValue);
+                            IFormField formField = new FormFieldImpl(parameterKey, preferredValue, parameter.getSecured());
+                            preferredParameters.put(parameterValue, formField);
                         }
                     }
                 }
             }
         }
-        mv.addObject("apps", apps);
-
         
-
-        
-        // iterate through all gateway entries and substitute preferences into entry values
-        for (GatewayEntry entry: entries) {
-            for (Map.Entry<HttpContentRequestImpl, List<String>> requestEntry : entry.getContentRequests().entrySet()){
-                
-                // run each content request through any configured preinterceptors
-                // before adding it to the list
-                final HttpContentRequestImpl contentRequest = requestEntry.getKey();
-                Map<String, String[]> parameters = contentRequest.getParameters();
-                for (String parameterKey: parameters.keySet()) {
-                    String[] parameterValues = parameters.get(parameterKey);
-                    for (int i = 0; i < parameterValues.length; i++) {
-//                        logger.warn("parameterKey: " + parameterKey + ", i: " + parameterValues[i]);
-                    }
-                }
-            }
-        }
-        
-        
-        mv.addObject("entries", entries);
+        mv.addObject("preferredParameters", preferredParameters);
         
         final String view = viewSelector.isMobile(request) ? mobileViewName : viewName;
         mv.setView(view);
@@ -180,78 +109,13 @@ public class GatewayPortletEditController {
     @RequestMapping(params = {"action=savePreferences"})
     public void savePreferences(ActionRequest request, ActionResponse response) throws Exception {
         PortletPreferences prefs = request.getPreferences();
-        logger.warn("savePreferences");
-        Map<String, Object> model = new LinkedHashMap<String, Object>();
         Enumeration<String> parameterNames = request.getParameterNames();
         while (parameterNames.hasMoreElements()) {
             String parameterName = parameterNames.nextElement();
             String parameterValue = request.getParameter(parameterName);
-            logger.warn("parameterName: " + parameterName + ", parameterValue: " + parameterValue);
-//            final String[] parameterValues = prefs.getValues(parameterName, new String[1]);
-//            parameterValues[0] = parameterValue;
             prefs.setValue(parameterName, parameterValue);
             prefs.store();
         }
-        
-        
-//        final PortletPreferences prefs = request.getPreferences();
-//        final List<SavedLocation> savedLocations = this.weatherService.getSavedLocations(prefs);
-//        
-//        if (savedLocations.size() != locationCodes.length) {
-//            model.put("status", "failure");
-//            model.put("message", "updated locations array is not the same size (" + locationCodes.length + ") as the saved locations array (" + savedLocations.size() + ")");
-//            this.ajaxPortletSupport.redirectAjaxResponse("ajax/json", model, request, response);
-//            return;
-//        }
-//        
-//        final Map<String, SavedLocation> locations = new LinkedHashMap<String, SavedLocation>();
-//        for (final SavedLocation savedLocation : savedLocations) {
-//            locations.put(savedLocation.code, savedLocation);
-//        }
-//        
-//        final List<SavedLocation> updatedLocations = new ArrayList<SavedLocation>(savedLocations.size());
-//        for (final String locationCode : locationCodes) {
-//            updatedLocations.add(locations.get(locationCode));
-//        }
-//        
-//        this.weatherService.saveLocations(updatedLocations, prefs);
-//        
-//        model.put("status", "success");
-//        this.ajaxPortletSupport.redirectAjaxResponse("ajax/json", model, request, response);
-    }
-
-    
-    
-    
-    @ResourceMapping()
-    public ModelAndView showTarget(ResourceRequest portletRequest, ResourceResponse portletResponse, @RequestParam("index") int index) throws IOException {     
-        final ModelAndView mv = new ModelAndView("json");
-        
-//        // get the requested gateway link entry from the list configured for
-//        // this portlet
-//        final List<GatewayEntry> entries =  (List<GatewayEntry>) applicationContext.getBean("gatewayEntries", List.class);
-//        final GatewayEntry entry = entries.get(index);
-//
-//        // build a list of content requests
-//        final List<HttpContentRequestImpl> contentRequests = new ArrayList<HttpContentRequestImpl>();
-//        for (Map.Entry<HttpContentRequestImpl, List<String>> requestEntry : entry.getContentRequests().entrySet()){
-//            
-//            // run each content request through any configured preinterceptors
-//            // before adding it to the list
-//            final HttpContentRequestImpl contentRequest = requestEntry.getKey();
-//            for (String interceptorKey : requestEntry.getValue()) {
-//                final IPreInterceptor interceptor = applicationContext.getBean(interceptorKey, IPreInterceptor.class);
-//                interceptor.intercept(contentRequest, portletRequest);
-//            }
-//            contentRequests.add(contentRequest);
-//        }
-//        mv.addObject("contentRequests", contentRequests);
-//
-//        // we don't want this response to be cached by the browser since it may
-//        // include one-time-only authentication tokens
-//        portletResponse.getCacheControl().setExpirationTime(1);
-//        portletResponse.getCacheControl().setUseCachedContent(false);
-
-        return mv;
+        response.setPortletMode(PortletMode.VIEW);
     }
 }

--- a/src/main/java/org/jasig/portlet/proxy/mvc/portlet/gateway/GatewayPortletEditController.java
+++ b/src/main/java/org/jasig/portlet/proxy/mvc/portlet/gateway/GatewayPortletEditController.java
@@ -1,0 +1,257 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portlet.proxy.mvc.portlet.gateway;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+import javax.portlet.PortletPreferences;
+import javax.portlet.ReadOnlyException;
+import javax.portlet.RenderRequest;
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
+import javax.portlet.ValidatorException;
+
+import org.jasig.portlet.proxy.mvc.IViewSelector;
+import org.jasig.portlet.proxy.mvc.portlet.gateway.GatewayEntry;
+import org.jasig.portlet.proxy.service.web.HttpContentRequestImpl;
+import org.jasig.portlet.proxy.service.web.interceptor.IPreInterceptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.portlet.ModelAndView;
+import org.springframework.web.portlet.bind.annotation.RenderMapping;
+import org.springframework.web.portlet.bind.annotation.ResourceMapping;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Controller
+@RequestMapping("EDIT")
+public class GatewayPortletEditController {
+    protected final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @Autowired(required=false)
+    private String viewName = "gatewayEdit";
+    
+    @Autowired(required=false)
+    private String mobileViewName = "mobileGatewayEdit";
+    
+    @Autowired(required=true)
+    private ApplicationContext applicationContext;
+    
+    @Autowired(required=true)
+    private IViewSelector viewSelector;
+
+    @RequestMapping
+    public ModelAndView getView(RenderRequest request){
+        final PortletPreferences preferences = request.getPreferences();
+
+        final ModelAndView mv = new ModelAndView();
+        final List<GatewayEntry> entries =  (List<GatewayEntry>) applicationContext.getBean("gatewayEntries", List.class);
+        
+        // debugging block, remove before committing
+//        logger.warn("Proxy entries");
+//        for (GatewayEntry entry: entries) {
+//            logger.warn("name: " + entry.getName());
+//            for (HttpContentRequestImpl key:  entry.getContentRequests().keySet()) {
+//                for (String strKey: key.getParameters().keySet()) {
+//                    String[] values = key.getParameters().get(strKey);
+//                    for (String val: values) {
+//                        logger.warn("\tkey: " + strKey + ", value: " + val); 
+//                    }
+//                }
+//            }
+//        }
+        logger.warn("Proxy Preferences");
+        Enumeration<String> names = preferences.getNames();
+        while (names.hasMoreElements()) {
+            String preferenceName = names.nextElement();
+            logger.warn("preferenceName: " + preferenceName);
+            final String[] abc = preferences.getValues(preferenceName, new String[0]);
+            if (abc.length > 0) {
+                logger.warn("abc.length: " + abc.length + ", value: " + abc[0]);
+            }
+        }
+        // end debugging block
+        
+        // perform substitution for any fields stored in userInfo, referenced in the config file
+//        for (GatewayEntry entry: entries) {
+//            for (Map.Entry<HttpContentRequestImpl, List<String>> requestEntry : entry.getContentRequests().entrySet()){
+//                
+//                // run each content request through any configured preinterceptors
+//                // before adding it to the list
+//                final HttpContentRequestImpl contentRequest = requestEntry.getKey();
+//                for (String interceptorKey : requestEntry.getValue()) {
+//                    final IPreInterceptor interceptor = applicationContext.getBean(interceptorKey, IPreInterceptor.class);
+//                    logger.warn("interceptor: " + interceptor.getClass().getCanonicalName());
+//                    interceptor.intercept(contentRequest, request);
+//                }
+//            }
+//        }
+        
+        Map<String, Map<String, String>> apps = new LinkedHashMap<String, Map<String, String>>();
+        for (GatewayEntry entry: entries) {
+//            logger.warn("entry: " + entry.getName());
+            for (Map.Entry<HttpContentRequestImpl, List<String>> requestEntry : entry.getContentRequests().entrySet()){
+                final HttpContentRequestImpl contentRequest = requestEntry.getKey();
+                Map<String, String[]> parameters = contentRequest.getParameters();
+                for (String parameterKey : parameters.keySet()) {
+//                    logger.warn("parameterKey: " + parameterKey);
+                    String[] parameterValues = parameters.get(parameterKey);
+                    for (int i = 0; i < parameterValues.length; i++) {
+                        String parameterValue = parameterValues[i];
+//                        logger.warn("parameterValue: " + parameterValue);
+                        if (parameterValue.matches("\\{prefs\\.[\\w.]+\\}")) {
+//                            logger.warn("regex match");
+                            Map<String, String> app = apps.get(entry.getName());
+                            if (app == null) {
+//                                logger.warn("add new app");
+                                app = new LinkedHashMap<String, String>();
+                                apps.put(entry.getName(), app);
+                            }
+                            
+                            // retrieve the preference and stuff the value here....
+                            PortletPreferences prefs = request.getPreferences();
+                            String preferredValue = prefs.getValue(parameterKey, parameterValue);
+                            
+                            
+                            app.put(parameterKey, preferredValue);
+                        }
+                    }
+                }
+            }
+        }
+        mv.addObject("apps", apps);
+
+        
+
+        
+        // iterate through all gateway entries and substitute preferences into entry values
+        for (GatewayEntry entry: entries) {
+            for (Map.Entry<HttpContentRequestImpl, List<String>> requestEntry : entry.getContentRequests().entrySet()){
+                
+                // run each content request through any configured preinterceptors
+                // before adding it to the list
+                final HttpContentRequestImpl contentRequest = requestEntry.getKey();
+                Map<String, String[]> parameters = contentRequest.getParameters();
+                for (String parameterKey: parameters.keySet()) {
+                    String[] parameterValues = parameters.get(parameterKey);
+                    for (int i = 0; i < parameterValues.length; i++) {
+//                        logger.warn("parameterKey: " + parameterKey + ", i: " + parameterValues[i]);
+                    }
+                }
+            }
+        }
+        
+        
+        mv.addObject("entries", entries);
+        
+        final String view = viewSelector.isMobile(request) ? mobileViewName : viewName;
+        mv.setView(view);
+        return mv;
+    }
+    
+    @RequestMapping(params = {"action=savePreferences"})
+    public void savePreferences(ActionRequest request, ActionResponse response) throws Exception {
+        PortletPreferences prefs = request.getPreferences();
+        logger.warn("savePreferences");
+        Map<String, Object> model = new LinkedHashMap<String, Object>();
+        Enumeration<String> parameterNames = request.getParameterNames();
+        while (parameterNames.hasMoreElements()) {
+            String parameterName = parameterNames.nextElement();
+            String parameterValue = request.getParameter(parameterName);
+            logger.warn("parameterName: " + parameterName + ", parameterValue: " + parameterValue);
+//            final String[] parameterValues = prefs.getValues(parameterName, new String[1]);
+//            parameterValues[0] = parameterValue;
+            prefs.setValue(parameterName, parameterValue);
+            prefs.store();
+        }
+        
+        
+//        final PortletPreferences prefs = request.getPreferences();
+//        final List<SavedLocation> savedLocations = this.weatherService.getSavedLocations(prefs);
+//        
+//        if (savedLocations.size() != locationCodes.length) {
+//            model.put("status", "failure");
+//            model.put("message", "updated locations array is not the same size (" + locationCodes.length + ") as the saved locations array (" + savedLocations.size() + ")");
+//            this.ajaxPortletSupport.redirectAjaxResponse("ajax/json", model, request, response);
+//            return;
+//        }
+//        
+//        final Map<String, SavedLocation> locations = new LinkedHashMap<String, SavedLocation>();
+//        for (final SavedLocation savedLocation : savedLocations) {
+//            locations.put(savedLocation.code, savedLocation);
+//        }
+//        
+//        final List<SavedLocation> updatedLocations = new ArrayList<SavedLocation>(savedLocations.size());
+//        for (final String locationCode : locationCodes) {
+//            updatedLocations.add(locations.get(locationCode));
+//        }
+//        
+//        this.weatherService.saveLocations(updatedLocations, prefs);
+//        
+//        model.put("status", "success");
+//        this.ajaxPortletSupport.redirectAjaxResponse("ajax/json", model, request, response);
+    }
+
+    
+    
+    
+    @ResourceMapping()
+    public ModelAndView showTarget(ResourceRequest portletRequest, ResourceResponse portletResponse, @RequestParam("index") int index) throws IOException {     
+        final ModelAndView mv = new ModelAndView("json");
+        
+//        // get the requested gateway link entry from the list configured for
+//        // this portlet
+//        final List<GatewayEntry> entries =  (List<GatewayEntry>) applicationContext.getBean("gatewayEntries", List.class);
+//        final GatewayEntry entry = entries.get(index);
+//
+//        // build a list of content requests
+//        final List<HttpContentRequestImpl> contentRequests = new ArrayList<HttpContentRequestImpl>();
+//        for (Map.Entry<HttpContentRequestImpl, List<String>> requestEntry : entry.getContentRequests().entrySet()){
+//            
+//            // run each content request through any configured preinterceptors
+//            // before adding it to the list
+//            final HttpContentRequestImpl contentRequest = requestEntry.getKey();
+//            for (String interceptorKey : requestEntry.getValue()) {
+//                final IPreInterceptor interceptor = applicationContext.getBean(interceptorKey, IPreInterceptor.class);
+//                interceptor.intercept(contentRequest, portletRequest);
+//            }
+//            contentRequests.add(contentRequest);
+//        }
+//        mv.addObject("contentRequests", contentRequests);
+//
+//        // we don't want this response to be cached by the browser since it may
+//        // include one-time-only authentication tokens
+//        portletResponse.getCacheControl().setExpirationTime(1);
+//        portletResponse.getCacheControl().setUseCachedContent(false);
+
+        return mv;
+    }
+}

--- a/src/main/java/org/jasig/portlet/proxy/security/IStringEncryptionService.java
+++ b/src/main/java/org/jasig/portlet/proxy/security/IStringEncryptionService.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portlet.proxy.security;
+
+/**
+ * IStringEncryptionService is a small interface for string encryption/decryption.
+ * It is expected that this service will generally consist of a small wrapper
+ * for some other encryption API.
+ * 
+ * @author bourey
+ */
+public interface IStringEncryptionService {
+    
+    /**
+     * Encrypt a string
+     * 
+     * @param plaintext
+     * @return encrypted version of the plaintext
+     * @throws StringEncryptionException
+     */
+    public String encrypt(String plaintext);
+    
+    /**
+     * Decrypt a string
+     * 
+     * @param cryptotext
+     * @return decrypted version of the cryptotext
+     * @throws StringEncryptionException
+     */
+    public String decrypt(String cryptotext);
+
+}

--- a/src/main/java/org/jasig/portlet/proxy/security/JasyptPBEStringEncryptionServiceImpl.java
+++ b/src/main/java/org/jasig/portlet/proxy/security/JasyptPBEStringEncryptionServiceImpl.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portlet.proxy.security;
+
+import org.jasypt.encryption.pbe.PBEStringEncryptor;
+import org.jasypt.exceptions.EncryptionInitializationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.Assert;
+
+/**
+ * JasyptPBEStringEncryptionServiceImpl is an implementation of 
+ * IStringEncryptionService that uses a configurable Jasypt PBEStringEncryptor
+ * to perform string encryption and decryption.
+ * 
+ * @author Jen Bourey
+ */
+public class JasyptPBEStringEncryptionServiceImpl implements IStringEncryptionService, InitializingBean {
+    protected final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+	private PBEStringEncryptor encryptor = null;
+	
+	/**
+	 * Set the PBEStringEncryptor to be used
+	 * 
+	 * @param encryptor
+	 */
+	public void setStringEncryptor(final PBEStringEncryptor encryptor) {
+		this.encryptor = encryptor;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	public String encrypt(final String plaintext) {
+		if (this.encryptor == null) {
+			logger.error("encryptor not set");
+		} else {
+			logger.error("encryptor is set");
+		}
+        try {
+            return this.encryptor.encrypt(plaintext);
+        } catch (EncryptionInitializationException e) {
+            logger.warn(e.getMessage(), e);
+            throw new StringEncryptionException("Encryption error. Verify an encryption password"
+                    + " is configured in the email preview portlet's"
+                    + " stringEncryptionService bean in applicationContent.xml", e);
+        }
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	public String decrypt(final String cryptotet) {
+		if (this.encryptor == null) {
+			logger.error("encryptor not set");
+		} else {
+			logger.error("encryptor is set");
+		}
+      try {
+	        return this.encryptor.decrypt(cryptotet);
+      } catch (EncryptionInitializationException e) {
+    	  logger.warn(e.getMessage(), e);
+          throw new StringEncryptionException("Decryption error. Was encryption password"
+                  + " changed in the email preview portlet's"
+                  + " stringEncryptionService bean in applicationContent.xml?", e);
+      }
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        final String enc = this.encrypt(this.getClass().getName());
+        Assert.notNull(enc, "String encryption service is not properly configured.");
+        
+        final String dec = this.decrypt(enc);
+        Assert.notNull(dec, "String decryption service is not properly configured.");
+        Assert.isTrue(dec.equals(this.getClass().getName()), "String decryption failed to decode the encrypted text " + enc);
+    }
+
+}

--- a/src/main/java/org/jasig/portlet/proxy/security/StringEncryptionException.java
+++ b/src/main/java/org/jasig/portlet/proxy/security/StringEncryptionException.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portlet.proxy.security;
+
+
+/**
+ * A custom Exception for the email preview portlet that may be thrown as the result 
+ * of a failure in encrypting/decrypting a string.
+ *
+ * @author Misagh Moayyed
+ * @see IStringEncryptionService
+ */
+public class StringEncryptionException extends RuntimeException {
+
+    private static final long serialVersionUID = 1l;
+    
+    public StringEncryptionException(Throwable cause) {
+        super(cause);
+    }
+
+    public StringEncryptionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public StringEncryptionException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/org/jasig/portlet/proxy/service/IFormField.java
+++ b/src/main/java/org/jasig/portlet/proxy/service/IFormField.java
@@ -1,7 +1,13 @@
 package org.jasig.portlet.proxy.service;
 
 /**
- * IFormField is an interface used to store form field information within an IContentRequest object.
+ * IFormField is an interface used to store form field information within an IContentRequest object.  
+ * The name getter/setter refer to the HTML input field name
+ * The value getter/setter refer to the value of the HTML input field name.  The value
+ * can contain either a static value or a value that will be substituted through a properly
+ * configured IPreInterceptor class
+ * The secured getter/setter refers to whether the field needs to be encrypted in the database
+ * and displayed as a password instead of a text html input field.
  * 
  * @author mgillian
  *
@@ -15,7 +21,7 @@ public interface IFormField {
 	public void setName(String name);
 	
 	/**
-	 * getName() gets the name of the field
+	 * getName() gets the name of the field.
 	 * @return
 	 */
 	public String getName();

--- a/src/main/java/org/jasig/portlet/proxy/service/IFormField.java
+++ b/src/main/java/org/jasig/portlet/proxy/service/IFormField.java
@@ -1,0 +1,65 @@
+package org.jasig.portlet.proxy.service;
+
+/**
+ * IFormField is an interface used to store form field information within an IContentRequest object.
+ * 
+ * @author mgillian
+ *
+ */
+public interface IFormField {
+	
+	/**
+	 * setName() sets the name of the field
+	 * @param name
+	 */
+	public void setName(String name);
+	
+	/**
+	 * getName() gets the name of the field
+	 * @return
+	 */
+	public String getName();
+	
+	/**
+	 * setValue() sets the first value of the field
+	 * @param value
+	 */
+	public void setValue(String value);
+	
+	/**
+	 * setValues() sets the value of the field
+	 * @param value
+	 */
+	public void setValues(String[] values);
+	
+	/**
+	 * getValue() returns the first value associated with the Field
+	 * @return
+	 */
+	public String getValue();
+	
+	/**
+	 * getValue() gets the value of the field
+	 * @return
+	 */
+	public String[] getValues();
+	
+	/**
+	 * isSecured() returns whether the field is encrypted and should be displayed obscured
+	 * to the user
+	 * @return true if field should be encrypted and secured, false otherwise
+	 */
+	public boolean isSecured();
+	
+	/**
+	 * isSecured(boolean) changes whether the field should be encrypted and obscured
+	 * @param isSecured
+	 */
+	public void isSecured(boolean isSecured);
+	
+	/**
+	 * duplicate() copies the data from the current IFormField into the passed-in parameter
+	 * @param copy a blank IFormField object that will receive a copy of the incoming data
+	 */
+	public void duplicate(IFormField copy);
+}

--- a/src/main/java/org/jasig/portlet/proxy/service/IFormField.java
+++ b/src/main/java/org/jasig/portlet/proxy/service/IFormField.java
@@ -45,17 +45,17 @@ public interface IFormField {
 	public String[] getValues();
 	
 	/**
-	 * isSecured() returns whether the field is encrypted and should be displayed obscured
+	 * getSecured() returns whether the field is encrypted and should be displayed obscured
 	 * to the user
 	 * @return true if field should be encrypted and secured, false otherwise
 	 */
-	public boolean isSecured();
+	public boolean getSecured();
 	
 	/**
-	 * isSecured(boolean) changes whether the field should be encrypted and obscured
+	 * setSecured(boolean) changes whether the field should be encrypted and obscured
 	 * @param isSecured
 	 */
-	public void isSecured(boolean isSecured);
+	public void setSecured(boolean isSecured);
 	
 	/**
 	 * duplicate() copies the data from the current IFormField into the passed-in parameter

--- a/src/main/java/org/jasig/portlet/proxy/service/web/FormFieldImpl.java
+++ b/src/main/java/org/jasig/portlet/proxy/service/web/FormFieldImpl.java
@@ -4,14 +4,19 @@ import org.jasig.portlet.proxy.service.IFormField;
 
 public class FormFieldImpl implements IFormField {
 	
-	private String name;
-	private String[] values;
-	private boolean secured;
+	private String name = "blankField";
+	private String[] values = new String[1];
+	private boolean secured = false;
 	
 	public FormFieldImpl() {
-		name = "blankField";
-		values = new String[1];
-		secured = false;
+	}
+	
+	public FormFieldImpl(String name, String value) {
+		this(name, value, false);
+	}
+	
+	public FormFieldImpl(String name, String value, boolean secured) {
+		this(name, new String[]{value}, secured);
 	}
 	
 	public FormFieldImpl(String name, String[] values) {
@@ -55,18 +60,20 @@ public class FormFieldImpl implements IFormField {
 	}
 
 	@Override
-	public boolean isSecured() {
+	public boolean getSecured() {
 		return this.secured;
 	}
 
 	@Override
-	public void isSecured(boolean isSecured) {
+	public void setSecured(boolean isSecured) {
 		this.secured = isSecured;
 	}
 
 	@Override
 	public void duplicate(IFormField copy) {
 		copy.setName(this.name);
+		copy.setSecured(this.getSecured());
+		
 		String[] values = this.getValues();
 		String[] copiedValues = new String[values.length];
 		System.arraycopy(values, 0, copiedValues, 0, values.length);

--- a/src/main/java/org/jasig/portlet/proxy/service/web/FormFieldImpl.java
+++ b/src/main/java/org/jasig/portlet/proxy/service/web/FormFieldImpl.java
@@ -1,0 +1,75 @@
+package org.jasig.portlet.proxy.service.web;
+
+import org.jasig.portlet.proxy.service.IFormField;
+
+public class FormFieldImpl implements IFormField {
+	
+	private String name;
+	private String[] values;
+	private boolean secured;
+	
+	public FormFieldImpl() {
+		name = "blankField";
+		values = new String[1];
+		secured = false;
+	}
+	
+	public FormFieldImpl(String name, String[] values) {
+		this(name, values, false);
+	}
+	
+	public FormFieldImpl(String name, String[] values, boolean secured) {
+		this.name = name;
+		this.values = values;
+		this.secured = secured;
+	}
+	
+	@Override
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+	
+	@Override
+	public void setValue(String value) {
+		this.values[0] = value;
+	}
+	
+	@Override
+	public void setValues(String[] values) {
+		this.values = values;
+	}
+
+	@Override
+	public String getValue() {
+		return this.values[0];
+	}
+	
+	@Override
+	public String[] getValues() {
+		return values;
+	}
+
+	@Override
+	public boolean isSecured() {
+		return this.secured;
+	}
+
+	@Override
+	public void isSecured(boolean isSecured) {
+		this.secured = isSecured;
+	}
+
+	@Override
+	public void duplicate(IFormField copy) {
+		copy.setName(this.name);
+		String[] values = this.getValues();
+		String[] copiedValues = new String[values.length];
+		System.arraycopy(values, 0, copiedValues, 0, values.length);
+		copy.setValues(copiedValues);
+	}
+}

--- a/src/main/java/org/jasig/portlet/proxy/service/web/HttpContentRequestImpl.java
+++ b/src/main/java/org/jasig/portlet/proxy/service/web/HttpContentRequestImpl.java
@@ -19,7 +19,9 @@
 package org.jasig.portlet.proxy.service.web;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentMap;
 
 import javax.portlet.PortletPreferences;
@@ -27,17 +29,18 @@ import javax.portlet.PortletRequest;
 import javax.portlet.PortletSession;
 
 import org.jasig.portlet.proxy.service.GenericContentRequestImpl;
+import org.jasig.portlet.proxy.service.IFormField;
 import org.jasig.portlet.proxy.service.proxy.document.URLRewritingFilter;
 
 public class HttpContentRequestImpl extends GenericContentRequestImpl {
 
-    private Map<String, String[]> parameters;
+    private Map<String, IFormField> parameters;
     private Map<String, String> headers;
     private String method;
     private boolean isForm;
     
     public HttpContentRequestImpl() { 
-    	this.parameters = new HashMap<String, String[]>();
+    	this.parameters = new HashMap<String, IFormField>();
     	this.headers = new HashMap<String, String>();
     }
     
@@ -68,7 +71,8 @@ public class HttpContentRequestImpl extends GenericContentRequestImpl {
         final Map<String, String[]> params = request.getParameterMap();
         for (Map.Entry<String, String[]> param : params.entrySet()) {
         	if (!param.getKey().startsWith(HttpContentServiceImpl.PROXY_PORTLET_PARAM_PREFIX)) {
-				this.parameters.put(param.getKey(), param.getValue());
+        		IFormField formField = new FormFieldImpl(param.getKey(), param.getValue());
+				this.parameters.put(param.getKey(), formField);
         	}
         }
         
@@ -77,11 +81,11 @@ public class HttpContentRequestImpl extends GenericContentRequestImpl {
 
     }
 
-	public Map<String, String[]> getParameters() {
+	public Map<String, IFormField> getParameters() {
 		return parameters;
 	}
 
-	public void setParameters(Map<String, String[]> parameters) {
+	public void setParameters(Map<String, IFormField> parameters) {
 		this.parameters = parameters;
 	}
 
@@ -108,5 +112,35 @@ public class HttpContentRequestImpl extends GenericContentRequestImpl {
 	public void setForm(boolean isForm) {
 		this.isForm = isForm;
 	}
-
+	
+	/**
+	 * duplicate() creates a duplicate of the HttpContentRequest without
+	 * using clone().  All objects are unique, but the data contained within
+	 * the objects is the same
+	 * @return a unique HttpContentRequestImpl object with the same data
+	 */
+	public HttpContentRequestImpl duplicate() {
+		HttpContentRequestImpl copy = new HttpContentRequestImpl();
+		copy.setMethod((String) this.getMethod());
+		copy.setForm(this.isForm());
+		copy.setProxiedLocation(this.getProxiedLocation());
+		
+		Map<String, String> copyHeaders = new LinkedHashMap<String, String>();
+		copyHeaders.putAll(this.headers);
+		copy.setHeaders(copyHeaders);
+		
+		// String[] needs to be copied manually, otherwise, you end up with the
+		// same object in the new HttpContentRequestImpl
+		Map<String, IFormField> copyParameters = new LinkedHashMap<String, IFormField>();
+		for (Entry<String, IFormField> requestEntry : this.getParameters().entrySet()){
+			String key = requestEntry.getKey();
+			IFormField values = requestEntry.getValue();
+			IFormField copiedValues = new FormFieldImpl();
+			values.duplicate(copiedValues);
+			copyParameters.put(key, copiedValues);
+		}
+		copy.setParameters(copyParameters);
+		
+		return copy;
+	}
 }

--- a/src/main/java/org/jasig/portlet/proxy/service/web/HttpContentServiceImpl.java
+++ b/src/main/java/org/jasig/portlet/proxy/service/web/HttpContentServiceImpl.java
@@ -46,6 +46,7 @@ import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.HttpContext;
 import org.jasig.portlet.proxy.service.GenericContentResponseImpl;
 import org.jasig.portlet.proxy.service.IContentService;
+import org.jasig.portlet.proxy.service.IFormField;
 import org.jasig.portlet.proxy.service.web.interceptor.IPreInterceptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -177,12 +178,12 @@ public class HttpContentServiceImpl implements IContentService<HttpContentReques
         if (proxyRequest.isForm()) {
 
             // handle POST form request
-            final Map<String, String[]> params = proxyRequest.getParameters();
+            final Map<String, IFormField> params = proxyRequest.getParameters();
             if ("POST".equalsIgnoreCase(proxyRequest.getMethod())) {
 
                 final List<NameValuePair> pairs = new ArrayList<NameValuePair>();
-                for (Map.Entry<String, String[]> param : params.entrySet()) {
-                    for (String value : param.getValue()) {
+                for (Map.Entry<String, IFormField> param : params.entrySet()) {
+                    for (String value : param.getValue().getValues()) {
                         if (value != null) {
                             pairs.add(new BasicNameValuePair(param.getKey(), value));
                         }
@@ -209,8 +210,8 @@ public class HttpContentServiceImpl implements IContentService<HttpContentReques
 
                     // build a URL including any passed form parameters
                     final URIBuilder builder = new URIBuilder(proxyRequest.getProxiedLocation());
-                    for (Map.Entry<String, String[]> param : params.entrySet()) {
-                        for (String value : param.getValue()) {
+                    for (Map.Entry<String, IFormField> param : params.entrySet()) {
+                        for (String value : param.getValue().getValues()) {
                             builder.addParameter(param.getKey(), value);
                         }
                     }

--- a/src/main/java/org/jasig/portlet/proxy/service/web/interceptor/UserInfoUrlParameterizingPreInterceptor.java
+++ b/src/main/java/org/jasig/portlet/proxy/service/web/interceptor/UserInfoUrlParameterizingPreInterceptor.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import javax.portlet.PortletRequest;
 
 
+import org.jasig.portlet.proxy.service.IFormField;
 import org.jasig.portlet.proxy.service.web.HttpContentRequestImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,12 +67,12 @@ public class UserInfoUrlParameterizingPreInterceptor implements IPreInterceptor 
 				// if any parameter values associated with the request contain
 				// {attributeName}, replace that string in the parameter with
 				// the attribute's value
-				for (Map.Entry<String, String[]> param : proxyRequest.getParameters().entrySet()) {
-					final int length = param.getValue().length;
+				for (Map.Entry<String, IFormField> param : proxyRequest.getParameters().entrySet()) {
+					final int length = param.getValue().getValues().length;
 					for (int i = 0; i < length; i++) {
-						String value = param.getValue()[i];
+						String value = param.getValue().getValues()[i];
 						if (value.contains(token)) {
-							param.getValue()[i] = value.replaceAll("\\{".concat(key).concat("\\}"), userInfo.get(key));
+							param.getValue().getValues()[i] = value.replaceAll("\\{".concat(key).concat("\\}"), userInfo.get(key));
 						}
 					}
 					

--- a/src/main/java/org/jasig/portlet/proxy/service/web/interceptor/UserPreferencesPreInterceptor.java
+++ b/src/main/java/org/jasig/portlet/proxy/service/web/interceptor/UserPreferencesPreInterceptor.java
@@ -1,0 +1,48 @@
+package org.jasig.portlet.proxy.service.web.interceptor;
+
+import java.util.Map;
+
+import javax.portlet.PortletPreferences;
+import javax.portlet.PortletRequest;
+
+import org.jasig.portlet.proxy.service.IFormField;
+import org.jasig.portlet.proxy.service.web.HttpContentRequestImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service("UserPreferencesPreInterceptor")
+public class UserPreferencesPreInterceptor implements IPreInterceptor {
+    protected final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    private String preferrencesRegex;
+    
+    @Value("${login.preferences.regex}")
+    public void setPreferrencesRegex(String preferrencesRegex) {
+        this.preferrencesRegex = preferrencesRegex;
+    }
+    
+	@Override
+	public void intercept(HttpContentRequestImpl proxyRequest,
+			PortletRequest portletRequest) {
+		logger.warn("UserPreferencesPreInterceptor.intercept");
+		logger.warn("regex: " + preferrencesRegex);
+		// TODO Auto-generated method stub
+		// replace the portlet preference fields with user specific entries
+        PortletPreferences prefs = portletRequest.getPreferences();
+
+		Map<String, IFormField> parameters = proxyRequest.getParameters();
+		for (String parameterKey: parameters.keySet()) {
+			String[] parameterValues = parameters.get(parameterKey).getValues();
+			for (int i = 0; i < parameterValues.length; i++) {
+				String parameterValue = parameterValues[i];
+				if (parameterValue.matches(preferrencesRegex)) {
+					String preferredValue = prefs.getValue(parameterValue, parameterValue);
+					parameterValues[i] = preferredValue;
+					logger.warn("key: " + parameterKey + ", substituting parameter value: " + preferredValue);
+				}
+		    }
+		}
+	}
+}

--- a/src/main/java/org/jasig/portlet/proxy/service/web/interceptor/UserPreferencesPreInterceptor.java
+++ b/src/main/java/org/jasig/portlet/proxy/service/web/interceptor/UserPreferencesPreInterceptor.java
@@ -16,31 +16,28 @@ import org.springframework.stereotype.Service;
 public class UserPreferencesPreInterceptor implements IPreInterceptor {
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    private String preferrencesRegex;
+    private String preferencesRegex;
     
-    @Value("${login.preferences.regex}")
-    public void setPreferrencesRegex(String preferrencesRegex) {
-        this.preferrencesRegex = preferrencesRegex;
+    @Value("#{props['login.preferences.regex']}")
+    public void setPreferencesRegex(String preferencesRegex) {
+        this.preferencesRegex = preferencesRegex;
     }
     
 	@Override
 	public void intercept(HttpContentRequestImpl proxyRequest,
 			PortletRequest portletRequest) {
-		logger.warn("UserPreferencesPreInterceptor.intercept");
-		logger.warn("regex: " + preferrencesRegex);
-		// TODO Auto-generated method stub
+		
 		// replace the portlet preference fields with user specific entries
-        PortletPreferences prefs = portletRequest.getPreferences();
-
+		PortletPreferences prefs = portletRequest.getPreferences();
+		
 		Map<String, IFormField> parameters = proxyRequest.getParameters();
 		for (String parameterKey: parameters.keySet()) {
 			String[] parameterValues = parameters.get(parameterKey).getValues();
 			for (int i = 0; i < parameterValues.length; i++) {
 				String parameterValue = parameterValues[i];
-				if (parameterValue.matches(preferrencesRegex)) {
+				if (parameterValue.matches(preferencesRegex)) {
 					String preferredValue = prefs.getValue(parameterValue, parameterValue);
 					parameterValues[i] = preferredValue;
-					logger.warn("key: " + parameterKey + ", substituting parameter value: " + preferredValue);
 				}
 		    }
 		}

--- a/src/main/resources/configuration.properties
+++ b/src/main/resources/configuration.properties
@@ -23,3 +23,4 @@ viewResCache=false
 cas.server.base.url=http://localhost:8080/cas
 portal.server.base.url=http://localhost:8080
 portlet.context=WebProxyPortlet
+login.preferences.regex=\\{prefs\\.[\\w.]+\\}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -20,3 +20,4 @@ edit.proxy.title=Proxy User IDs and Passwords
 edit.proxy.column.value=Value
 edit.proxy.column.name=Name
 edit.proxy.save.preferences=Save Preferences
+edit.proxy.show.preferences.link=Manage My Logins

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -16,4 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
+edit.proxy.title=Proxy User IDs and Passwords
+edit.proxy.column.value=Value
+edit.proxy.column.name=Name
+edit.proxy.save.preferences=Save Preferences

--- a/src/main/webapp/WEB-INF/context/applicationContext.xml
+++ b/src/main/webapp/WEB-INF/context/applicationContext.xml
@@ -45,9 +45,11 @@
         <property name="location" value="classpath:configuration.properties" />
     </bean>
 
+    <util:properties id="props" location="classpath:configuration.properties"/>
+
     <!-- Message source for this context, loaded from localized "messages_xx" files -->
     <bean id="messageSource" class="org.springframework.context.support.ResourceBundleMessageSource"
-        p:basenames="i18n/messages" p:useCodeAsDefaultMessage="true"/>
+        p:basenames="messages" p:useCodeAsDefaultMessage="true"/>
 
     <bean class="org.apache.http.impl.conn.PoolingClientConnectionManager"
         p:maxTotal="50" p:defaultMaxPerRoute="10"/>

--- a/src/main/webapp/WEB-INF/context/applicationContext.xml
+++ b/src/main/webapp/WEB-INF/context/applicationContext.xml
@@ -131,5 +131,14 @@
         <property name="prefix" value="/WEB-INF/jsp/"/>
         <property name="suffix" value=".jsp"/>
     </bean>
+    
+    <bean id="stringEncryptionService" class="org.jasig.portlet.proxy.security.JasyptPBEStringEncryptionServiceImpl">
+        <property name="stringEncryptor">
+            <bean class="org.jasypt.encryption.pbe.StandardPBEStringEncryptor">
+                 <property name="password" value="verylongsalt"/>
+            </bean>
+        </property>
+    </bean>
+    
 
 </beans>

--- a/src/main/webapp/WEB-INF/context/portlet/gateway-sso-portlet.xml
+++ b/src/main/webapp/WEB-INF/context/portlet/gateway-sso-portlet.xml
@@ -1,0 +1,147 @@
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:context="http://www.springframework.org/schema/context" xmlns:p="http://www.springframework.org/schema/p"
+    xmlns:util="http://www.springframework.org/schema/util"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+      http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+      http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+    <context:component-scan base-package="org.jasig.portlet.proxy.mvc.portlet.gateway" />
+    <context:annotation-config />
+    
+    <bean
+        class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="location" value="classpath:configuration.properties" />
+    </bean>
+    <util:list id="gatewayEntries" scope="session">
+        <!--
+            Gateway SSO allows the user to sign onto remote systems through capture of credentials and
+            replay of those credentials on remote systems.  Each bean in the contentRequest list is for a 
+            different system.  The parameters property lists the fields that will be added to a form and then
+            submitted to the proxiedLocation in order to authenticate.  The formFieldImpl class contains three
+            fields: the field name and value, and whether the field is secured.  Secured is only relevant at this
+            point for the portlet preferences interceptor, since those preferences must be stored in the database
+            and are presented to the user in an HTML password input field, instead of an HTML text input field. 
+         -->
+        <!-- 
+            <bean class="org.jasig.portlet.proxy.mvc.portlet.gateway.GatewayEntry" p:name="Zimbra"
+                p:iconUrl="/ResourceServingWebapp/rs/tango/0.8.90/32x32/apps/internet-mail.png">
+            <property name="contentRequests">
+                <util:map>
+                    <entry>
+                        <key>
+                            <bean class="org.jasig.portlet.proxy.service.web.HttpContentRequestImpl" p:proxiedLocation="https://zimbra.unicon.net/zimbra/"
+                                p:form="true" p:method="POST">
+                                <property name="parameters">
+                                    <util:map>
+                                        <entry>
+                                            <key><value>loginOp</value></key>
+                                            <bean class="org.jasig.portlet.proxy.service.web.FormFieldImpl">
+                                                <property name="name" value="loginOp"/>
+                                                <property name="value" value="login"/>
+                                            </bean>
+                                        </entry>
+                                        <entry>
+                                            <key><value>username</value></key>
+                                            <bean class="org.jasig.portlet.proxy.service.web.FormFieldImpl">
+                                                <property name="name" value="username"/>
+                                                <property name="value" value="{user.login.id}"/>
+                                            </bean>
+                                        </entry>
+                                        <entry>
+                                            <key><value>password</value></key>
+                                            <bean class="org.jasig.portlet.proxy.service.web.FormFieldImpl">
+                                                <property name="name" value="password"/>
+                                                <property name="value" value="{password}"/>
+                                            </bean>
+                                        </entry>
+                                    </util:map>
+                                </property>
+                            </bean>
+                        </key>
+                        <util:list>
+                            <value>userInfoUrlParameterizingPreInterceptor</value>
+                        </util:list>
+                    </entry>
+                </util:map>
+            </property>
+        </bean>
+        -->
+        <!--
+        The following bean shows two intereceptors.  userInfoUrlParameterizingPreInterceptor
+        will replace parameters with information from userInfo.  UserPreferencesPreInterceptor
+        will replace parameters with information stored in portal preferences for the current user.
+        Refer to those two classes for the format of values that will be substituted.
+         -->
+        <!-- 
+        <bean class="org.jasig.portlet.proxy.mvc.portlet.gateway.GatewayEntry" p:name="MyZimbra"
+                p:iconUrl="/ResourceServingWebapp/rs/tango/0.8.90/32x32/apps/internet-mail.png">
+            <property name="contentRequests">
+                <util:map>
+                    <entry>
+                        <key>
+                            <bean class="org.jasig.portlet.proxy.service.web.HttpContentRequestImpl" p:proxiedLocation="https://zimbra.unicon.net/zimbra/"
+                                p:form="true" p:method="POST">
+                                <property name="parameters">
+                                    <util:map>
+                                        <entry>
+                                            <key><value>loginOp</value></key>
+                                            <bean class="org.jasig.portlet.proxy.service.web.FormFieldImpl">
+                                                <property name="name" value="loginOp"/>
+                                                <property name="value" value="login"/>
+                                            </bean>
+                                        </entry>
+                                        <entry>
+                                            <key><value>username</value></key>
+                                            <bean class="org.jasig.portlet.proxy.service.web.FormFieldImpl">
+                                                <property name="name" value="username"/>
+                                                <property name="value" value="{prefs.myzimbra.uid}"/>
+                                            </bean>
+                                        </entry>
+                                        <entry>
+                                            <key><value>password</value></key>
+                                            <bean class="org.jasig.portlet.proxy.service.web.FormFieldImpl">
+                                                <property name="name" value="password"/>
+                                                <property name="value" value="{prefs.myzimbra.pwd}"/>
+                                                <property name="secured" value="true"/>
+                                            </bean>
+                                        </entry>
+                                    </util:map>
+                                </property>
+                            </bean>
+                        </key>
+                        <util:list>
+                            <value>userInfoUrlParameterizingPreInterceptor</value>
+                            <value>UserPreferencesPreInterceptor</value>
+                        </util:list>
+                    </entry>
+                </util:map>
+            </property>
+        </bean>
+        -->
+    </util:list>
+    <bean class="org.springframework.web.portlet.mvc.annotation.DefaultAnnotationHandlerMapping">
+        <property name="interceptors"><bean class="org.jasig.portlet.proxy.mvc.MinimizedStateHandlerInterceptor"/></property>
+    </bean>
+
+</beans>

--- a/src/main/webapp/WEB-INF/jsp/gateway.jsp
+++ b/src/main/webapp/WEB-INF/jsp/gateway.jsp
@@ -27,7 +27,7 @@
     <c:forEach items="${ entries }" var="entry">
         <p class="entry">
             
-            <a href="javascript:;" target="_blank">
+            <a href="javascript:;" target="_self">
                 <img src="${entry.iconUrl}" style="vertical-align: middle; text-decoration: none; padding-right: 10px;"/>${ entry.name }
             </a>
         </p>
@@ -50,14 +50,13 @@
                             .attr("action", contentRequest.proxiedLocation)
                             .attr("method", contentRequest.method);
                         
-                        $.each(contentRequest.parameters, function (key, values) {
-                            $(values).each(function (idx, value) {
-                                form.append($(document.createElement("input")).attr("name", key).attr("value", value));
+                        $.each(contentRequest.parameters, function (key, formFields) {
+                            $(formFields).each(function (idx, formField) {
+                                form.append($(document.createElement("input")).attr("name", key).attr("value", formField.value));
                             });
                         });
-                        console.log(form);
 
-                        form.submit();
+                        form.appendTo("body").submit();
                     } else {
                         window.location = contentRequest.proxiedLocation;
                     }

--- a/src/main/webapp/WEB-INF/jsp/gateway.jsp
+++ b/src/main/webapp/WEB-INF/jsp/gateway.jsp
@@ -32,7 +32,14 @@
             </a>
         </p>
     </c:forEach>
+    
 </div>
+
+<div class="edit-link">
+    <portlet:renderURL var="editUrl"  portletMode="EDIT" windowState="MAXIMIZED" />
+    <a href="${editUrl}"><spring:message code="edit.proxy.show.preferences.link"/></a>
+</div>
+    
 
 <script type="text/javascript">
     up.jQuery(function () {
@@ -73,10 +80,10 @@
                 }
             };
             
-    		$("#${n} .entry a").each(function (idx, link) {
-    			$(link).click(function () {
-    				$.get(
-						"${ requestsUrl }", 
+            $("#${n} .entry a").each(function (idx, link) {
+                $(link).click(function () {
+                    $.get(
+                    	"${ requestsUrl }", 
 						{ index: idx }, 
 						function (data) { 
 							var contentRequests = data.contentRequests;

--- a/src/main/webapp/WEB-INF/jsp/gatewayEdit.jsp
+++ b/src/main/webapp/WEB-INF/jsp/gatewayEdit.jsp
@@ -35,21 +35,23 @@
         <table id="${n}savedLocationsTable">
             <thead>
                 <tr>
-                    <th><spring:message code="edit.proxy.column.order"/></th>
                     <th><spring:message code="edit.proxy.column.name"/></th>
-                    <th><spring:message code="edit.proxy.column.userId"/></th>
-                    <th><spring:message code="edit.proxy.column.password"/></th>
+                    <th><spring:message code="edit.proxy.column.value"/></th>
                 </tr>
             </thead>
             <tbody>
-                <c:forEach var="app" items="${apps }">
-                    <c:forEach var="prop" items="${app.value}">
+                <c:forEach var="preferredParameter" items="${preferredParameters }">
                         <tr>
-                            <td>${app.key }</td>
-                            <td>${prop.key }</td>
-                            <td><input type="text" name="${prop.key}" value="${prop.value}" /></td>
+                            <td>${preferredParameter.key }</td>
+                            <c:choose>
+                                <c:when test="${preferredParameter.value.secured == true }">
+                                    <td><input type="password" name="${preferredParameter.key}" value="${preferredParameter.value.value }" /></td>
+                                </c:when>
+                                <c:otherwise>
+                                    <td><input type="text" name="${preferredParameter.key}" value="${preferredParameter.value.value}" /></td>
+                                </c:otherwise>
+                            </c:choose>
                         </tr>
-                    </c:forEach>
                 </c:forEach>
             </tbody>
         </table>
@@ -57,8 +59,5 @@
         <input type="submit" value="${savePreferencesLabel }" class="portlet-form-button"/>
         
         </form>
-
-        <portlet:renderURL var="formDoneAction" portletMode="VIEW" windowState="NORMAL"/>
-        <p><button onclick="window.location='${formDoneAction}'" class="portlet-form-button"><spring:message code="edit.done.button"/></button></p>
     </div>
 </div>

--- a/src/main/webapp/WEB-INF/jsp/gatewayEdit.jsp
+++ b/src/main/webapp/WEB-INF/jsp/gatewayEdit.jsp
@@ -1,0 +1,64 @@
+<%--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+--%>
+
+<%-- Author: Dustin Schultz | Version $Id$ --%>
+<%@ include file="/WEB-INF/jsp/include.jsp" %>
+
+<portlet:actionURL var="savePreferencesUrl">
+    <portlet:param name="action" value="savePreferences"/>
+</portlet:actionURL>
+
+<div id="${n}jasigWeatherPortlet" class="jasigWeatherPortlet">
+
+    <div class="passwords">
+
+        <h2><spring:message code="edit.proxy.title"/></h2>
+        <form id="${n}addLocationForm" class="select-location-form" action="${savePreferencesUrl}" method="post">
+        <table id="${n}savedLocationsTable">
+            <thead>
+                <tr>
+                    <th><spring:message code="edit.proxy.column.order"/></th>
+                    <th><spring:message code="edit.proxy.column.name"/></th>
+                    <th><spring:message code="edit.proxy.column.userId"/></th>
+                    <th><spring:message code="edit.proxy.column.password"/></th>
+                </tr>
+            </thead>
+            <tbody>
+                <c:forEach var="app" items="${apps }">
+                    <c:forEach var="prop" items="${app.value}">
+                        <tr>
+                            <td>${app.key }</td>
+                            <td>${prop.key }</td>
+                            <td><input type="text" name="${prop.key}" value="${prop.value}" /></td>
+                        </tr>
+                    </c:forEach>
+                </c:forEach>
+            </tbody>
+        </table>
+        <spring:message var="savePreferencesLabel" code="edit.proxy.save.preferences"/>
+        <input type="submit" value="${savePreferencesLabel }" class="portlet-form-button"/>
+        
+        </form>
+
+        <portlet:renderURL var="formDoneAction" portletMode="VIEW" windowState="NORMAL"/>
+        <p><button onclick="window.location='${formDoneAction}'" class="portlet-form-button"><spring:message code="edit.done.button"/></button></p>
+    </div>
+</div>

--- a/src/main/webapp/WEB-INF/jsp/mobileGatewayEdit.jsp
+++ b/src/main/webapp/WEB-INF/jsp/mobileGatewayEdit.jsp
@@ -1,0 +1,28 @@
+<%--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+--%>
+
+<%@ include file="/WEB-INF/jsp/include.jsp" %>
+<portlet:resourceURL var="requestsUrl" escapeXml="false"/>
+<c:set var="n"><portlet:namespace/></c:set>
+
+<div id="${n}">
+    hello
+</div>

--- a/src/main/webapp/WEB-INF/jsp/mobileGatewayEdit.jsp
+++ b/src/main/webapp/WEB-INF/jsp/mobileGatewayEdit.jsp
@@ -19,10 +19,45 @@
 
 --%>
 
+<%-- Author: Dustin Schultz | Version $Id$ --%>
 <%@ include file="/WEB-INF/jsp/include.jsp" %>
-<portlet:resourceURL var="requestsUrl" escapeXml="false"/>
-<c:set var="n"><portlet:namespace/></c:set>
 
-<div id="${n}">
-    hello
+<portlet:actionURL var="savePreferencesUrl">
+    <portlet:param name="action" value="savePreferences"/>
+</portlet:actionURL>
+
+<div id="${n}jasigWeatherPortlet" class="jasigWeatherPortlet">
+
+    <div class="passwords">
+
+        <h2><spring:message code="edit.proxy.title"/></h2>
+        <form id="${n}addLocationForm" class="select-location-form" action="${savePreferencesUrl}" method="post">
+        <table id="${n}savedLocationsTable">
+            <thead>
+                <tr>
+                    <th><spring:message code="edit.proxy.column.name"/></th>
+                    <th><spring:message code="edit.proxy.column.value"/></th>
+                </tr>
+            </thead>
+            <tbody>
+                <c:forEach var="preferredParameter" items="${preferredParameters }">
+                        <tr>
+                            <td>${preferredParameter.key }</td>
+                            <c:choose>
+                                <c:when test="${preferredParameter.value.secured == true }">
+                                    <td><input type="password" name="${preferredParameter.key}" value="${preferredParameter.value.value }" /></td>
+                                </c:when>
+                                <c:otherwise>
+                                    <td><input type="text" name="${preferredParameter.key}" value="${preferredParameter.value.value}" /></td>
+                                </c:otherwise>
+                            </c:choose>
+                        </tr>
+                </c:forEach>
+            </tbody>
+        </table>
+        <spring:message var="savePreferencesLabel" code="edit.proxy.save.preferences"/>
+        <input type="submit" value="${savePreferencesLabel }" class="portlet-form-button"/>
+        
+        </form>
+    </div>
 </div>

--- a/src/main/webapp/WEB-INF/portlet.xml
+++ b/src/main/webapp/WEB-INF/portlet.xml
@@ -38,6 +38,7 @@
         <supports>
             <mime-type>text/html</mime-type>
             <portlet-mode>view</portlet-mode>
+            <portlet-mode>edit</portlet-mode>
             <portlet-mode>config</portlet-mode>
         </supports>
         <portlet-info>

--- a/src/test/java/org/jasig/portlet/proxy/service/web/HttpContentRequestImplTest.java
+++ b/src/test/java/org/jasig/portlet/proxy/service/web/HttpContentRequestImplTest.java
@@ -1,0 +1,81 @@
+package org.jasig.portlet.proxy.service.web;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.jasig.portlet.proxy.service.IFormField;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HttpContentRequestImplTest {
+	
+	@Before
+	public void setUp() {
+		
+	}
+	
+	@Test
+	/**
+	 * ensures duplicate() returns a unique object by duplicating an object,
+	 * changing the original, and then ensuring that the duplicate and the original
+	 * are not the same
+	 */
+	public void testDuplicate() {
+		final String originalMethod = "post"; 
+		final String newMethod = "get";
+		
+		final String originalProxiedLocation = "http://www.yahoo.com";
+		final String newProxiedLocation = "http://www.espn.com";
+		
+		final String originalHeaderKey = "headerKey";
+		final String originalHeaderValue = "headerValue";
+		final String newHeaderValue = "newHeaderValue";
+		
+		final String originalParameterKey = "parameterA";
+		final String originalParameterValue1 = "A";
+		final String originalParameterValue2 = "B";
+		final String newParameterValue1 = "99";
+		
+		Map<String, IFormField> parameters = new LinkedHashMap<String, IFormField>();
+		IFormField parameter = new FormFieldImpl();
+		parameter.setName(originalParameterKey);
+		String[] values ={ originalParameterValue1, originalParameterValue2};
+		parameter.setValues(values);
+		parameters.put(originalParameterKey,  parameter);
+		
+		Map<String, String> headers = new LinkedHashMap<String, String>();
+		headers.put(originalHeaderKey, originalHeaderValue);
+		
+		HttpContentRequestImpl original = new HttpContentRequestImpl();
+		original.setForm(true);
+		original.setProxiedLocation(originalProxiedLocation);
+		original.setMethod(originalMethod);
+		original.setHeaders(headers);
+		original.setParameters(parameters);
+		
+		HttpContentRequestImpl copy = original.duplicate();
+		
+		assertEquals(copy.isForm(), true);
+		assertEquals(copy.getMethod(), originalMethod);
+		assertEquals(copy.getProxiedLocation(), originalProxiedLocation);
+		assertEquals(copy.getHeaders().get(originalHeaderKey), originalHeaderValue);
+		IFormField copyParameter = copy.getParameters().get(originalParameterKey);
+		assertEquals(copyParameter.getValues()[0], originalParameterValue1);
+		assertEquals(copyParameter.getValues()[1], originalParameterValue2);
+		
+		original.setForm(false);
+		original.setProxiedLocation(newProxiedLocation);
+		original.setMethod(newMethod);
+		IFormField originalParameter = original.getParameters().get(originalParameterKey);
+		originalParameter.getValues()[0] = newParameterValue1;
+		original.getHeaders().put(originalHeaderKey, newHeaderValue);
+		
+		assertNotSame(original.isForm(), copy.isForm());
+		assertNotSame(original.getMethod(), copy.getMethod());
+		assertNotSame(original.getProxiedLocation(), copy.getProxiedLocation());
+		assertNotSame(original.getParameters().get(originalParameterKey), copy.getParameters().get(originalParameterKey));
+		assertNotSame(original.getHeaders().get(originalHeaderKey), copy.getHeaders().get(originalHeaderKey));
+	}
+}

--- a/src/test/java/org/jasig/portlet/proxy/service/web/interceptor/UserInfoUrlParameterizingPreInterceptorTest.java
+++ b/src/test/java/org/jasig/portlet/proxy/service/web/interceptor/UserInfoUrlParameterizingPreInterceptorTest.java
@@ -26,6 +26,8 @@ import java.util.Map;
 
 import javax.portlet.PortletRequest;
 
+import org.jasig.portlet.proxy.service.IFormField;
+import org.jasig.portlet.proxy.service.web.FormFieldImpl;
 import org.jasig.portlet.proxy.service.web.HttpContentRequestImpl;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,7 +39,7 @@ public class UserInfoUrlParameterizingPreInterceptorTest {
 	UserInfoUrlParameterizingPreInterceptor preprocessor;
 	@Mock PortletRequest portletRequest;
 	HttpContentRequestImpl proxyRequest;
-	Map<String, String[]> parameters;
+	Map<String, IFormField> parameters;
 	Map<String, String> userInfoMap;
 	
 	@Before
@@ -46,7 +48,7 @@ public class UserInfoUrlParameterizingPreInterceptorTest {
 		
 		preprocessor = new UserInfoUrlParameterizingPreInterceptor();
 		
-		parameters = new HashMap<String, String[]>();
+		parameters = new HashMap<String, IFormField>();
 		userInfoMap = new HashMap<String, String>();
 		
 		when(portletRequest.getAttribute(PortletRequest.USER_INFO)).thenReturn(userInfoMap);
@@ -60,11 +62,12 @@ public class UserInfoUrlParameterizingPreInterceptorTest {
 
 	@Test
 	public void testNoChange() {
-		parameters.put("test", new String[]{"somevalue"});
+		IFormField formField = new FormFieldImpl("test", new String[]{"somevalue"});
+		parameters.put("test", formField);
 		
 		preprocessor.intercept(proxyRequest, portletRequest);
 		assertEquals("http://somewhere.com/rest/test/id", proxyRequest.getProxiedLocation());
-		assertEquals("somevalue", proxyRequest.getParameters().get("test")[0]);
+		assertEquals("somevalue", proxyRequest.getParameters().get("test").getValues()[0]);
 	}
 
 	@Test
@@ -78,11 +81,12 @@ public class UserInfoUrlParameterizingPreInterceptorTest {
 	
 	@Test
 	public void testReplaceParamter() {
-		parameters.put("param", new String[]{"val1", "{test}"});
+		IFormField formField = new FormFieldImpl("param", new String[]{"val1", "{test}"});
+		parameters.put("param", formField);
 		preprocessor.intercept(proxyRequest, portletRequest);
 		
-		assertEquals("val1", proxyRequest.getParameters().get("param")[0]);
-		assertEquals("somevalue", proxyRequest.getParameters().get("param")[1]);
+		assertEquals("val1", proxyRequest.getParameters().get("param").getValues()[0]);
+		assertEquals("somevalue", proxyRequest.getParameters().get("param").getValues()[1]);
 	}
 
 }


### PR DESCRIPTION
In addition to authenticating with remote systems via the uPortal user info, users can now authenticate with portlet preferences.  User enters their credentials for remote systems, which are then encrypted and persisted and used for playback authentication on other systems.
